### PR TITLE
[BLR-189] Fix Sass imports order

### DIFF
--- a/assets/source/css/parent.scss
+++ b/assets/source/css/parent.scss
@@ -15,12 +15,16 @@
 @import 'jigsass-tools-selectors/scss/index';
 @import 'jigsass-generic-normalize/scss/index';
 
-// Mixins & placeholders
+// Mixins
 @import 'abstracts/mixins';
+
+// Reset
+@import 'base/reset';
+
+// Placeholders
 @import 'abstracts/placeholders';
 
 // Base styles
-@import 'base/reset';
 @import 'base/defaults';
 @import 'base/typography';
 


### PR DESCRIPTION
- Import placeholders after the reset module to prevent reset styles
  from overriding placeholder styles
