### PR TITLE
Fix Page Templates

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -122,13 +122,32 @@ function display_sidebar( $sidebar = 'sidebar-primary' ) {
 
 	// Sidebar will be hidden if any of the following is true.
 	$hide_criteria = [
-		( ! is_active_sidebar( $sidebar ) && 'sidebar-secondary' !== $sidebar ),
-		is_404(),
+		'all' => [
+			is_404(),
+			( ! is_active_sidebar( $sidebar ) ),
+		],
+		'sidebar-primary' => [
+			is_page_template( 'page-templates/full-width.php' ),
+			is_page_template( 'page-templates/sidebar-secondary.php' ),
+		],
+		'sidebar-secondary' => [
+			is_page_template( 'page-templates/full-width.php' ),
+			is_page_template( 'page-templates/sidebar-primary.php' ),
+		],
 	];
 
-	$display = ( ! in_array( true, $hide_criteria, true ) );
+	// Check default criteria for hiding sidebar.
+	$display = ( ! in_array( true, $hide_criteria['all'], true );
+
+	// If specific criteria exist for the current sidebar, check that as well.
+	if ( isset( $hide_criteria[ $sidebar ] ) ) {
+		$display = ( $display && ! in_array( true, $hide_criteria[ $sidebar ], true );
+	}
+
+	// Filter the current display value to allow for custom child theme layouts.
 	$display = apply_filters( 'blr-base-theme/display_sidebar', $display, $sidebar );
 	$display = apply_filters( 'blr/display_sidebar', $display, $sidebar );
+	$display = apply_filters( 'blr/display/sidebar', $display, $sidebar );
 
 	return $display;
 }
@@ -151,6 +170,7 @@ function display_nav_menu( $menu = 'nav-primary' ) {
 	$display = ( ! in_array( true, $hide_criteria, true ) );
 	$display = apply_filters( 'blr-base-theme/display_nav_menu', $display, $menu );
 	$display = apply_filters( 'blr/display_nav_menu', $display, $menu );
+	$display = apply_filters( 'blr/display/nav-menu', $display, $menu );
 
 	return $display;
 }
@@ -171,6 +191,7 @@ function display_breadcrumbs() {
 
 	$display = ( ! in_array( true, $hide_criteria, true ) );
 	$display = apply_filters( 'blr/display_breadcrumbs', $display );
+	$display = apply_filters( 'blr/display/breadcrumbs', $display );
 
 	return $display;
 }

--- a/page-templates/full-width.php
+++ b/page-templates/full-width.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Template Name: Secondary Sidebar
+ * Template Name: Full Width (no sidebars)
  *
- * @package BLR\Base_Theme\Templates
+ * @package BLR\Base_Theme\Page_Templates
  */
 
 while ( have_posts() ) : the_post(); ?>

--- a/page-templates/sidebar-primary.php
+++ b/page-templates/sidebar-primary.php
@@ -2,7 +2,7 @@
 /**
  * Template Name: Primary Sidebar
  *
- * @package BLR\Base_Theme\Templates
+ * @package BLR\Base_Theme\Page_Templates
  */
 
 while ( have_posts() ) : the_post(); ?>

--- a/page-templates/sidebar-secondary.php
+++ b/page-templates/sidebar-secondary.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Template Name: Full Width (no sidebars)
+ * Template Name: Secondary Sidebar
  *
- * @package BLR\Base_Theme\Templates
+ * @package BLR\Base_Theme\Page_Templates
  */
 
 while ( have_posts() ) : the_post(); ?>


### PR DESCRIPTION
Move page templates into `page-templates` folder and remove the `page-`
prefix from each file name. WordPress looks for a template named
`page-{$slug}` when rendering single pages, and as such it's bad
practice to start a page template with `page-`.

I also included the `is_page_template()` checks from TTMARK in the
sidebar display filter callback and (finally) settled on a consistent
naming convention for the various display filters.
