### PR TITLE
Only apply `%content-sub-section` to children of `%content-section`

### DIFF
--- a/assets/source/css/frontend/layout/_main-content.scss
+++ b/assets/source/css/frontend/layout/_main-content.scss
@@ -24,12 +24,12 @@ main,
 
 .content-section {
 	@extend %content-section;
-}
 
-.entry__header,
-.entry__content,
-.entry__footer {
-	@extend %content-sub-section;
+	.entry__header,
+	.entry__content,
+	.entry__footer {
+		@extend %content-sub-section;
+	}
 }
 
 @include breakpoint( md ) {


### PR DESCRIPTION
This way, the `.content-section` class can be removed and these
styles not applied.

Fixes #46
