### PR TITLE
BLRBT-3: Bump version to 0.7.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "blr-base-theme",
   "description": "A base theme for WordPress sites. Based on Sage by Roots.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://github.com/Decisionary/blr-base-theme",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "decisionary/blr-base-theme",
   "type": "wordpress-theme",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A base theme for BLR WordPress sites. Based on Sage by Roots.",
   "homepage": "https://github.com/Decisionary/blr-base-theme",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@decisionary/blr-base-theme",
   "description": "A base theme for WordPress sites. Based on Sage by Roots.",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://github.com/Decisionary/blr-base-theme",
   "repository": {

--- a/style.css
+++ b/style.css
@@ -4,5 +4,5 @@ Description:  Parent theme for BLR WordPress projects.
 Author:       Decisionary
 Author URI:   https://www.decisionarytech.com/
 Text Domain:  blr-base-theme
-Version:      0.7.1
+Version:      0.7.2
 */


### PR DESCRIPTION
This is required so TTMARK can target the new version of BLRBT. Currently it's pulling in 0.7.1, which does not include these changes.
