### PR TITLE
BLRBT-18: Fix malformed widget HTML

### DIFF
--- a/assets/source/css/frontend/abstracts/_placeholders.scss
+++ b/assets/source/css/frontend/abstracts/_placeholders.scss
@@ -118,6 +118,10 @@
 	position: relative;
 	color: $color-widget;
 
+	%widget__title {
+		color: $color-widget-header;
+	}
+
 	> * {
 		@extend %content-sub-section;
 	}
@@ -125,10 +129,6 @@
 	ul {
 		margin-left: 0;
 		list-style: none;
-	}
-
-	%widget__title {
-		color: $color-widget-header;
 	}
 }
 

--- a/assets/source/css/frontend/abstracts/_placeholders.scss
+++ b/assets/source/css/frontend/abstracts/_placeholders.scss
@@ -113,17 +113,18 @@
 
 %widget {
 	@extend %content-section;
+	@extend %text-content;
 
 	position: relative;
 	color: $color-widget;
 
 	> * {
 		@extend %content-sub-section;
-		@extend %text-content;
 	}
 
 	ul {
-		list-style-position: inside;
+		margin-left: 0;
+		list-style: none;
 	}
 
 	%widget__title {

--- a/assets/source/css/frontend/abstracts/_placeholders.scss
+++ b/assets/source/css/frontend/abstracts/_placeholders.scss
@@ -2,40 +2,8 @@
 /// @group Abstracts
 ////
 
+@import 'abstracts/placeholders/typography';
 @import 'abstracts/placeholders/nav';
-
-%text-content {
-	* {
-		// Default line spacing.
-		+ * {
-			@include v-spacing-top;
-		}
-
-		// Sub-headings.
-		+ h2,
-		+ h3 {
-			@include v-spacing-top( $line-spacing-heading );
-		}
-
-		// List items.
-		+ li,
-		+ dt,
-		+ dd {
-			@include v-spacing-top( $line-spacing-list-item );
-		}
-	}
-
-	ul,
-	ol,
-	dl {
-		margin-left: 1.5em;
-		list-style-position: outside;
-	}
-
-	dt {
-		font-weight: bold;
-	}
-}
 
 %content-section,
 %content-sub-section {

--- a/assets/source/css/frontend/abstracts/_placeholders.scss
+++ b/assets/source/css/frontend/abstracts/_placeholders.scss
@@ -4,6 +4,39 @@
 
 @import 'abstracts/placeholders/nav';
 
+%text-content {
+	* {
+		// Default line spacing.
+		+ * {
+			@include v-spacing-top;
+		}
+
+		// Sub-headings.
+		+ h2,
+		+ h3 {
+			@include v-spacing-top( $line-spacing-heading );
+		}
+
+		// List items.
+		+ li,
+		+ dt,
+		+ dd {
+			@include v-spacing-top( $line-spacing-list-item );
+		}
+	}
+
+	ul,
+	ol,
+	dl {
+		margin-left: 1.5em;
+		list-style-position: outside;
+	}
+
+	dt {
+		font-weight: bold;
+	}
+}
+
 %content-section,
 %content-sub-section {
 	@include susy-clearfix;
@@ -116,9 +149,13 @@
 	position: relative;
 	color: $color-widget;
 
-	%widget__title,
-	%widget__content {
+	> * {
 		@extend %content-sub-section;
+		@extend %text-content;
+	}
+
+	ul {
+		list-style-position: inside;
 	}
 
 	%widget__title {
@@ -152,8 +189,7 @@
 		content: '';
 	}
 
-	%widget__title,
-	%widget__content {
+	> * {
 		padding: {
 			right: $padding-base;
 			left: $padding-base;

--- a/assets/source/css/frontend/abstracts/placeholders/_typography.scss
+++ b/assets/source/css/frontend/abstracts/placeholders/_typography.scss
@@ -1,0 +1,36 @@
+////
+/// @group Abstracts
+////
+
+%text-content {
+	* {
+		// Default line spacing.
+		+ * {
+			@include v-spacing-top;
+		}
+
+		// Sub-headings.
+		+ h2,
+		+ h3 {
+			@include v-spacing-top( $line-spacing-heading );
+		}
+
+		// List items.
+		+ li,
+		+ dt,
+		+ dd {
+			@include v-spacing-top( $line-spacing-list-item );
+		}
+	}
+
+	ul,
+	ol,
+	dl {
+		margin-left: 1.5em;
+		list-style-position: outside;
+	}
+
+	dt {
+		font-weight: bold;
+	}
+}

--- a/assets/source/css/frontend/base/_typography.scss
+++ b/assets/source/css/frontend/base/_typography.scss
@@ -49,37 +49,6 @@ dl {
 }
 
 .content-section,
-.entry__content,
-.widget__content {
-
-	* {
-		// Default line spacing.
-		+ * {
-			@include v-spacing-top;
-		}
-
-		// Sub-headings.
-		+ h2,
-		+ h3 {
-			@include v-spacing-top( $line-spacing-heading );
-		}
-
-		// List items.
-		+ li,
-		+ dt,
-		+ dd {
-			@include v-spacing-top( $line-spacing-list-item );
-		}
-	}
-
-	ul,
-	ol,
-	dl {
-		margin-left: 1.5em;
-		list-style-position: outside;
-	}
-
-	dt {
-		font-weight: bold;
-	}
+.entry__content {
+	@extend %text-content;
 }

--- a/assets/source/css/frontend/components/_widget.scss
+++ b/assets/source/css/frontend/components/_widget.scss
@@ -10,10 +10,6 @@
 	@extend %widget__title;
 }
 
-.widget__content {
-	@extend %widget__content;
-}
-
 .widget--call-to-action {
 
 	.button-group {

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -61,14 +61,10 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup' );
  */
 function widgets_init() {
 
-	// There is an issue where the opening `.widget__content` div is not
-	// included if the widgets doesn't have a title. If we can't find a way to
-	// reliably wrap the widget content in this `.widget__content` div we'll
-	// probably need to remove it and find another way to style the widgets.
 	$defaults = [
 		'before_widget' => '<section class="widget--boxed %1$s %2$s">',
 		'before_title'  => '<h3 class="widget__title">',
-		'after_title'   => '</h3><div class="widget__content">',
+		'after_title'   => '</h3>',
 		'after_widget'  => '</section>',
 	];
 
@@ -140,9 +136,6 @@ function widget_args( $instance, $widget, $args ) {
 				<span class="nav-toggle__icon"></span>
 			</button>';
 		$args['after_widget'] = '</nav>';
-
-		// Remove the '.widget__content' div.
-		$args['after_title'] = '</h3>';
 
 		// Display the widget.
 		$widget->widget( $args, $instance );


### PR DESCRIPTION
- Removes the `.widget__content` wrapper since there's no reliable way to wrap the widget content for widgets without a title.
- Updates widget styles to account for the `.widget__content` wrapper being gone.
